### PR TITLE
Feature/port over auth logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .nrepl-port
 /.nrepl-history
 /logs/
+/config/.private.edn

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wombats
 
+![wombat_git](https://cloud.githubusercontent.com/assets/4649439/17083937/59e5a5f0-517d-11e6-92a2-976aee52d95c.png)
+
 ### About Wombats
 
 TODO: Mission Statement / Goals

--- a/build.boot
+++ b/build.boot
@@ -7,6 +7,9 @@
                             [org.clojure/clojure   "1.9.0-alpha14"]
                             [org.clojure/data.json "0.2.6"]
 
+                            ;; JSON Parsing
+                            [cheshire "5.7.0"]
+
                             ;; Environment configuration
                             [environ         "1.1.0"]
                             [levand/immuconf "0.1.0"]
@@ -24,6 +27,9 @@
                             [io.pedestal/pedestal.service "0.5.1"]
                             [io.pedestal/pedestal.jetty   "0.5.1"]
                             ;; [io.pedestal/pedestal.immutant "0.5.1"]
+
+                            ;; HTTP Client
+                            [http-kit "2.3.0-alpha1"]
 
                             ;; Logging
                             [org.slf4j/jul-to-slf4j     "1.7.21"]

--- a/config/base.edn
+++ b/config/base.edn
@@ -4,4 +4,7 @@
             :join? false
             :container-options {:h2c? true
                                 :h2? false
-                                :ssl? true}}}
+                                :ssl? true}}
+ :github {:client-id #immuconf/override "Add your applications github client id to config/.private.edn"
+          :client-secret #immuconf/override "Add your applications github client secret to config/.private.edn"
+          :signing-secret #immuconf/default "shhhhh....."}}

--- a/config/base.edn
+++ b/config/base.edn
@@ -7,4 +7,5 @@
                                 :ssl? true}}
  :github {:client-id #immuconf/override "Add your applications github client id to config/.private.edn"
           :client-secret #immuconf/override "Add your applications github client secret to config/.private.edn"
-          :signing-secret #immuconf/default "shhhhh....."}}
+          :signing-secret #immuconf/default "shhhhh....."
+          :web-client-redirect #immuconf/override "Specify the location of the web client"}}

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -1,3 +1,4 @@
 {:datomic {:uri "datomic:free://localhost:4334/wombats-dev"}
  :pedestal {:port 8888
-            :container-options {:ssl? false}}}
+            :container-options {:ssl? false}}
+ :github {:web-client-redirect "http://localhost:8888"}}

--- a/resources/datomic/schema.edn
+++ b/resources/datomic/schema.edn
@@ -1,29 +1,32 @@
 [;; User entities
- {:db/id #db/id [:db.part/db]
+ {:db/id          #db/id [:db.part/db]
   :db/ident       :user/username
   :db/valueType   :db.type/string
   :db/cardinality :db.cardinality/one
-  :db/doc "A user's username"
-  :db.install/_attribute :db.part/db}
+  :db/doc         "A user's username"}
 
- {:db/id #db/id [:db.part/db]
+ {:db/id          #db/id [:db.part/db]
+  :db/ident       :user/github-name
+  :db/valueType   :db.type/string
+  :db/unique      :db.unique/identity
+  :db/cardinality :db.cardinality/one
+  :db/doc         "Users GitHub username."}
+
+ {:db/id          #db/id [:db.part/db]
   :db/ident       :user/wombats
   :db/valueType   :db.type/ref
   :db/cardinality :db.cardinality/many
-  :db/doc "All the wombats that belong to a user"
-  :db.install/_attribute :db.part/db}
+  :db/doc         "All the wombats that belong to a user"}
 
  ;; Wombat entities
- {:db/id #db/id [:db.part/db]
+ {:db/id          #db/id [:db.part/db]
   :db/ident       :wombat/name
   :db/valueType   :db.type/string
   :db/cardinality :db.cardinality/one
-  :db/doc "A Wombats name"
-  :db.install/_attribute :db.part/db}
+  :db/doc         "A Wombats name"}
 
- {:db/id #db/id [:db.part/db]
+ {:db/id          #db/id [:db.part/db]
   :db/ident       :wombat/url
   :db/valueType   :db.type/string
   :db/cardinality :db.cardinality/one
-  :db/doc "The location of the wombat executable"
-  :db.install/_attribute :db.part/db}]
+  :db/doc         "The location of the wombat executable"}]

--- a/src/wombats/components/configuration.clj
+++ b/src/wombats/components/configuration.clj
@@ -19,11 +19,12 @@
 (defn- get-config-files
   "Determins the files that should be used for configuration.
 
-   Defaults -> [config/base.edn, config/{env}.edn]"
+   Defaults -> [config/base.edn, /config/.private.edn,  config/{env}.edn]"
   [env]
   (let [base-config "base.edn"
+        private-config ".private.edn"
         env-config (str (name env) ".edn")]
-    [base-config env-config]))
+    [base-config private-config env-config]))
 
 (defn- build-settings-map
   "Takes a vector of file paths, checks their existance, and runs the remaining

--- a/src/wombats/components/datomic.clj
+++ b/src/wombats/components/datomic.clj
@@ -8,6 +8,7 @@
 (defn- create-db-connection
   [config]
   (let [datomic-uri (get-in config [:settings :datomic :uri] nil)
+        ;; _ (d/delete-database datomic-uri)
         _ (d/create-database datomic-uri)
         conn (d/connect datomic-uri)]
     (d/transact conn (load-file "resources/datomic/schema.edn"))

--- a/src/wombats/components/service.clj
+++ b/src/wombats/components/service.clj
@@ -19,7 +19,9 @@
       component
       (assoc component :service (bootstrap-service config
                                                    route-map
-                                                   {:datomic datomic}))))
+                                                   {:datomic datomic
+                                                    :github (get-in config [:settings
+                                                                            :github])}))))
   (stop [component]
     (if-not service
       component

--- a/src/wombats/handlers/auth.clj
+++ b/src/wombats/handlers/auth.clj
@@ -1,6 +1,8 @@
 (ns wombats.handlers.auth
   (:require [io.pedestal.interceptor.helpers :refer [defbefore]]
             [clojure.core.async :refer [chan go >!]]
+            [org.httpkit.client :as http]
+            [cheshire.core :refer [parse-string]]
             [wombats.interceptors.github :refer [get-github-settings]]))
 
 (def ^:private github-base "https://github.com/login/oauth/")
@@ -10,6 +12,26 @@
 (def ^:private user-repos-url "https://api.github.com/user/repos")
 
 (def ^:private github-scopes "user:email")
+
+(defn- get-access-token
+  "POST request to get a GitHub OAuth token.
+  If no auth token is found, nil will return"
+  [request-params]
+  (http/post github-access-token-url
+             request-params
+             (fn [{:keys [body]}]
+               (get (parse-string body true) :access_token nil))))
+
+(defn- redirect-home
+  "Final redirect home with or without access token appended"
+  ([context]
+   (assoc context :response (assoc (:response context)
+                                   :headers {"Location" "/"}
+                                   :status 302)))
+  ([context access-token]
+   (assoc context :response (assoc (:response context)
+                                   :headers {"Location" (str "/?access-token=" access-token)}
+                                   :status 302))))
 
 ;; TODO signing secret should not be consistant across requests. Gen uuid to send.
 (defbefore github-redirect
@@ -24,22 +46,22 @@
       (>! ch (assoc context :response (assoc response
                                              :headers {"Location" github-redirect}
                                              :status 302
-                                             :body ""))))
+                                             :body nil))))
     ch))
 
 (defbefore github-callback
   [{:keys [request response] :as context}]
   (let [ch (chan 1)
-        {:keys [client-id client-secret]} (get-github-settings context)
-        {:keys [code state]} (:query-params request)
-        github-access-token-endpoint (str github-access-token-url
-                                          "?client_id=" client-id
-                                          "&client_secret=" client-secret
-                                          "&code=" code)]
+        {:keys [client-id client-secret signing-secret]} (get-github-settings context)
+        {:keys [code state]} (:query-params request)]
     (go
-      ;; TODO Fetch auth code
-      (>! ch (assoc context :response (assoc response
-                                             :headers {"Content-Type" "text/html"}
-                                             :status 200
-                                             :body "Callback"))))
+      (if (= state signing-secret)
+        (let [access-token @(get-access-token {:query-params {:client_id client-id
+                                                              :client_secret client-secret
+                                                              :code code}
+                                               :headers {"Accept" "application/json"}})]
+          (if access-token
+            (>! ch (redirect-home context access-token))
+            (>! ch (redirect-home context))))
+        (>! ch (redirect-home context))))
     ch))

--- a/src/wombats/handlers/auth.clj
+++ b/src/wombats/handlers/auth.clj
@@ -1,0 +1,45 @@
+(ns wombats.handlers.auth
+  (:require [io.pedestal.interceptor.helpers :refer [defbefore]]
+            [clojure.core.async :refer [chan go >!]]
+            [wombats.interceptors.github :refer [get-github-settings]]))
+
+(def ^:private github-base "https://github.com/login/oauth/")
+(def ^:private github-authorize-url (str github-base "authorize"))
+(def ^:private github-access-token-url (str github-base "access_token"))
+(def ^:private user-profile-url "https://api.github.com/user")
+(def ^:private user-repos-url "https://api.github.com/user/repos")
+
+(def ^:private github-scopes "user:email")
+
+;; TODO signing secret should not be consistant across requests. Gen uuid to send.
+(defbefore github-redirect
+  [{:keys [response] :as context}]
+  (let [ch (chan 1)
+        {:keys [client-id signing-secret]} (get-github-settings context)
+        github-redirect (str github-authorize-url
+                             "?client_id=" client-id
+                             "&scope=" github-scopes
+                             "&state=" signing-secret)]
+    (go
+      (>! ch (assoc context :response (assoc response
+                                             :headers {"Location" github-redirect}
+                                             :status 302
+                                             :body ""))))
+    ch))
+
+(defbefore github-callback
+  [{:keys [request response] :as context}]
+  (let [ch (chan 1)
+        {:keys [client-id client-secret]} (get-github-settings context)
+        {:keys [code state]} (:query-params request)
+        github-access-token-endpoint (str github-access-token-url
+                                          "?client_id=" client-id
+                                          "&client_secret=" client-secret
+                                          "&code=" code)]
+    (go
+      ;; TODO Fetch auth code
+      (>! ch (assoc context :response (assoc response
+                                             :headers {"Content-Type" "text/html"}
+                                             :status 200
+                                             :body "Callback"))))
+    ch))

--- a/src/wombats/interceptors/github.clj
+++ b/src/wombats/interceptors/github.clj
@@ -1,0 +1,12 @@
+(ns wombats.interceptors.github)
+
+(defn add-github-settings
+  "Attaches the github settings map to context"
+  [github-settings]
+  {:name ::github-settings
+   :enter (fn [context] (assoc context ::github-settings github-settings))})
+
+(defn get-github-settings
+  "Helper method used to extract github settings from the context map"
+  [context]
+  (::github-settings context))


### PR DESCRIPTION
This gets the auth workflow working in the new FW. 

GET -> `/api/v1/auth/github/signin` will trigger the workflow and return the user to the url specified in the corresponding environment config file. 

ex: `dev`

*config/dev.edn*

```clj
{:datomic {:uri "datomic:free://localhost:4334/wombats-dev"}
  :pedestal {:port 8888
                   :container-options {:ssl? false}}}
                   :container-options {:ssl? false}}
 :github {:web-client-redirect "http://localhost:8888"}}
```

`web-client-redirect` will be the final redirect in the workflow. Note: the `access-token` query param will be present in the url as a query parameter if the signin was successful.

TODO; Database persistence is still WIP so this will not save any user information. 
  