### PR TITLE
Add logout support

### DIFF
--- a/src/wombats/daos/core.clj
+++ b/src/wombats/daos/core.clj
@@ -14,6 +14,7 @@
    :get-user-by-id (user/get-user-by-id conn)
    :get-user-by-email (user/get-user-by-email conn)
    :get-user-by-access-token (user/get-user-by-access-token conn)
+   :remove-access-token (user/remove-access-token conn)
    :create-or-update-user (user/create-or-update-user conn)
    ;; Wombat Management DAOS
    :get-user-wombats (user/get-user-wombats conn)

--- a/src/wombats/daos/user.clj
+++ b/src/wombats/daos/user.clj
@@ -58,6 +58,15 @@
                                                :user/id (gen-id)})])
         (d/transact-async conn [update])))))
 
+(defn remove-access-token
+  [conn]
+  (fn [access-token]
+    (let [user ((get-user-by-access-token conn) access-token)]
+      (if user
+        (d/transact-async conn [[:db/retract (:db/id user)
+                                 :user/access-token access-token]])
+        (future)))))
+
 (defn get-user-wombats
   "Returns all wombats belonging to a specified user"
   [conn]

--- a/src/wombats/handlers/swagger.clj
+++ b/src/wombats/handlers/swagger.clj
@@ -6,7 +6,7 @@
 (def ^{:private true
        :doc "List of handlers to be sources for api documentation"}
   handlers
-  #{"user" "game" "arena"})
+  #{"user" "game" "arena" "auth"})
 
 (def ^:private swagger-specs {:info {:title "Wombats API"
                                      :description "API documentation for Wombats"
@@ -22,6 +22,8 @@
                               :produces ["application/edn"]
                               :tags [{:name "user"
                                       :description "User API"}
+                                     {:name "auth"
+                                      :description "Authentication API"}
                                      {:name "arena"
                                       :description "Arena Configuration API"}
                                      {:name "game"

--- a/src/wombats/interceptors/current_user.clj
+++ b/src/wombats/interceptors/current_user.clj
@@ -9,3 +9,7 @@
                   get-user (get-fn :get-user-by-access-token context)
                   user (when access-token (get-user access-token))]
               (assoc context ::current-user user)))})
+
+(defn get-current-user
+  [context]
+  (::current-user context))

--- a/src/wombats/routes.clj
+++ b/src/wombats/routes.clj
@@ -68,7 +68,9 @@
          ["/github"
           ^:interceptors [(add-github-settings github)]
           ["/signin"
-           {:get auth/github-redirect}]
+           {:get auth/signin}]
+          ["/signout"
+           {:get auth/signout}]
           ["/callback"
            {:get auth/github-callback}]]]]]]]))
 


### PR DESCRIPTION
Closes #142

- Remove access token from the db. This ensures that no one can reuse that token to interact with the wombat system.
- Add auth docs to swagger
- Rename login route