### PR TITLE
Feature/refactor auth logic

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -21,6 +21,9 @@
                             ;; Scheduler
                             [jarohen/chime "0.2.0"]
 
+                            ;; Token Support
+                            [buddy "1.3.0"]
+
                             ;; Environment configuration
                             [environ         "1.1.0"]
                             [levand/immuconf "0.1.0"]

--- a/config/base.edn
+++ b/config/base.edn
@@ -14,4 +14,5 @@
           :signing-secret #immuconf/default "shhhhh....."
           :web-client-redirect #immuconf/override "Specify the location of the web client"}
  :aws {:access-key-id #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_AWS_ACCESS_KEY_ID"
-       :secret-key #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_AWS_SECRET_KEY"}}
+       :secret-key #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_AWS_SECRET_KEY"}
+ :security {:signing-secret #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_SIGNING_SECRET"}}

--- a/resources/datomic/schema.edn
+++ b/resources/datomic/schema.edn
@@ -33,11 +33,18 @@
   :db/doc         "A user's wombat handle"}
 
  {:db/id          #db/id [:db.part/db]
-  :db/ident       :user/access-token
+  :db/ident       :user/github-access-token
   :db/valueType   :db.type/string
   :db/unique      :db.unique/identity
   :db/cardinality :db.cardinality/one
   :db/doc         "A user's GitHub auth token."}
+
+ {:db/id          #db/id [:db.part/db]
+  :db/ident       :user/access-token
+  :db/valueType   :db.type/string
+  :db/unique      :db.unique/identity
+  :db/cardinality :db.cardinality/one
+  :db/doc         "A user's wombat auth token."}
 
  {:db/id          #db/id [:db.part/db]
   :db/ident       :user/github-username
@@ -47,16 +54,10 @@
 
  {:db/id          #db/id [:db.part/db]
   :db/ident       :user/github-id
+  :db/unique      :db.unique/identity
   :db/valueType   :db.type/long
   :db/cardinality :db.cardinality/one
   :db/doc         "A user's GitHub id."}
-
- {:db/id          #db/id [:db.part/db]
-  :db/ident       :user/email
-  :db/valueType   :db.type/string
-  :db/unique      :db.unique/identity
-  :db/cardinality :db.cardinality/one
-  :db/doc         "A user's email from their GitHub account."}
 
  {:db/id          #db/id [:db.part/db]
   :db/ident       :user/avatar-url

--- a/src/wombats/components/configuration.clj
+++ b/src/wombats/components/configuration.clj
@@ -28,12 +28,14 @@
   (let [wombat-envs (select-keys env [:wombats-aws-access-key-id
                                       :wombats-aws-secret-key
                                       :wombats-github-client-id
-                                      :wombats-github-client-secret])
+                                      :wombats-github-client-secret
+                                      :wombats-signing-secret])
         file-name "/tmp/wombats-config.edn"
         formatted-config {:github (remove-nil {:client-id (:wombats-github-client-id wombat-envs)
                                                :client-secret (:wombats-github-client-secret wombat-envs)})
                           :aws (remove-nil {:access-key-id (:wombats-aws-access-key-id wombat-envs)
-                                            :secret-key (:wombats-aws-secret-key wombat-envs)})}]
+                                            :secret-key (:wombats-aws-secret-key wombat-envs)})
+                          :security (remove-nil {:signing-secret (:wombats-signing-secret wombat-envs)})}]
     (spit file-name (str formatted-config))
     (io/file file-name)))
 

--- a/src/wombats/components/service.clj
+++ b/src/wombats/components/service.clj
@@ -20,10 +20,9 @@
       (assoc component :service (bootstrap-service config
                                                    route-map
                                                    {:datomic datomic
-                                                    :github (get-in config [:settings
-                                                                            :github])
-                                                    :aws (get-in config [:settings
-                                                                         :aws])}))))
+                                                    :github (get-in config [:settings :github])
+                                                    :aws (get-in config [:settings :aws])
+                                                    :security (get-in config [:settings :security])}))))
   (stop [component]
     (if-not service
       component

--- a/src/wombats/daos/core.clj
+++ b/src/wombats/daos/core.clj
@@ -14,6 +14,7 @@
    :get-users (user/get-users conn)
    :get-user-by-id (user/get-user-by-id conn)
    :get-user-by-email (user/get-user-by-email conn)
+   :get-user-by-github-id (user/get-user-by-github-id conn)
    :get-user-by-access-token (user/get-user-by-access-token conn)
    :remove-access-token (user/remove-access-token conn)
    :create-or-update-user (user/create-or-update-user conn)

--- a/src/wombats/daos/game.clj
+++ b/src/wombats/daos/game.clj
@@ -261,7 +261,7 @@
                              (pull ?stats [*])
                              (pull ?user [:db/id
                                           :user/github-username
-                                          :user/access-token])
+                                          :user/github-access-token])
                              (pull ?wombat [*])
                        :in $ ?game-id
                        :where [?game :game/id ?game-id]

--- a/src/wombats/game/initializers.clj
+++ b/src/wombats/game/initializers.clj
@@ -69,7 +69,8 @@
   (map (fn [[player-eid {:keys [wombat user]}]]
          (let [url (str "https://api.github.com/repos" (:wombat/url wombat))
                auth-headers {:headers {"Accept" "application/json"
-                                       "Authorization" (str "token " (:user/access-token user))}}
+                                       "Authorization" (str "token "
+                                                            (:user/github-access-token user))}}
                ch (async/chan 1)]
            (async/go
              (let [resp @(http/get url auth-headers)]

--- a/src/wombats/handlers/auth.clj
+++ b/src/wombats/handlers/auth.clj
@@ -94,24 +94,26 @@
                    web-client-redirect]} (get-github-settings context)
            {:keys [code state]} (:query-params request)
            failed-callback (redirect-home context web-client-redirect)]
-
        (if (= state signing-secret)
-         (let [access-token @(get-access-token {:client_id client-id
-                                                :client_secret client-secret
-                                                :code code})
+         (let [github-access-token @(get-access-token {:client_id client-id
+                                                       :client_secret client-secret
+                                                       :code code})
                ;; TODO BUG If the user does not have their email setup on GH this
                ;; step will fail
-               user (when access-token
-                      (parse-user-response @(get-github-user access-token)))
+               user (when github-access-token
+                      (parse-user-response @(get-github-user github-access-token)))
                create-or-update-user (dao/get-fn :create-or-update-user context)
-               get-user-by-email (dao/get-fn :get-user-by-email context)]
-           (if (and access-token user)
-             (let [user-update (select-keys user [:email :login :id :avatar_url])
-                   current-user (get-user-by-email (:email user-update))
+               get-user-by-github-id (dao/get-fn :get-user-by-github-id context)]
+           (if (and github-access-token user)
+             (let [user-update (select-keys user [:login :id :avatar_url])
+                   user-access-token (gen-user-access-token (get-hashing-secret context)
+                                                            (:id user-update))
+                   current-user (get-user-by-github-id (:id user-update))
                    updated-user @(create-or-update-user user-update
-                                                        access-token
+                                                        github-access-token
+                                                        user-access-token
                                                         (:user/id current-user))]
-               (redirect-home context web-client-redirect access-token))
+               (redirect-home context web-client-redirect user-access-token))
              failed-callback))
          failed-callback)))))
 

--- a/src/wombats/handlers/auth.clj
+++ b/src/wombats/handlers/auth.clj
@@ -2,7 +2,10 @@
   (:require [io.pedestal.interceptor.helpers :as interceptor]
             [org.httpkit.client :as http]
             [cheshire.core :refer [parse-string]]
+            [buddy.core.mac :as mac]
+            [buddy.core.codecs :as codecs]
             [wombats.interceptors.github :refer [get-github-settings]]
+            [wombats.interceptors.authorization :refer [get-hashing-secret]]
             [wombats.daos.helpers :as dao]))
 
 (def ^:private github-base "https://github.com/login/oauth/")
@@ -72,6 +75,13 @@
                                        :headers {"Location" github-redirect}
                                        :status 302
                                        :body nil))))))
+
+(defn- gen-user-access-token
+  "Generates an access token to be used by the wombats client"
+  [secret-key github-id]
+  (-> (str github-id)
+      (mac/hash {:key secret-key :alg :hmac+sha256})
+      (codecs/bytes->hex)))
 
 (def github-callback
   "Callback handler from GitHub OAuth request"

--- a/src/wombats/interceptors/authorization.clj
+++ b/src/wombats/interceptors/authorization.clj
@@ -1,5 +1,11 @@
 (ns wombats.interceptors.authorization)
 
+(defn add-security-settings
+  "Adds the security settings map to context"
+  [security-settings]
+  {:name ::security-settings
+   :enter (fn [context] (assoc context ::security-settings security-settings))})
+
 (defn authorization-error
   "Throws an error that will be caught by the exception interceptor."
   ([]
@@ -11,3 +17,7 @@
                    {:type :unauthorized
                     :message message
                     :reason data}))))
+
+(defn get-hashing-secret
+  [context]
+  (get-in context [::security-settings :signing-secret]))

--- a/src/wombats/routes.clj
+++ b/src/wombats/routes.clj
@@ -6,6 +6,7 @@
             [wombats.interceptors.dao :refer [add-dao-functions]]
             [wombats.interceptors.current-user :refer [add-current-user]]
             [wombats.interceptors.github :refer [add-github-settings]]
+            [wombats.interceptors.authorization :refer [add-security-settings]]
             [wombats.interceptors.error-handler :refer [service-error-handler]]
             [wombats.handlers.swagger :as swagger]
             [wombats.handlers.static-pages :as static]
@@ -21,6 +22,7 @@
   [services]
   (let [datomic (get-in services [:datomic :database])
         github (:github services)
+        security (:security services)
         aws-credentials (:aws services)]
     [[["/"
        ^:interceptors [html-body]
@@ -71,7 +73,8 @@
 
         ["/auth"
          ["/github"
-          ^:interceptors [(add-github-settings github)]
+          ^:interceptors [(add-security-settings security)
+                          (add-github-settings github)]
           ["/signin"
            {:get auth/signin}]
           ["/signout"


### PR DESCRIPTION
## Refactor Auth Logic:

### Problem 

Users attempting to signin in without a public email address will receive an error from the API.

### Cause 

We currently use the email field returning from GitHub as a unique id to look up our users. If it doesn't exist we are unable to look up users. It also fails when trying to insert a new user, (nil error with Datomic)

### Solution

Switch to using the `id` property returning from github.

### Also in this PR

- We no longer send back the github auth token on signin to be used in api requests. We now send back a new token (independent from users gh accounts) to be used to increase security and support logout (while still maintaining the user's gh access token). 