### PR TITLE
Removed web-client-redirect from config

### DIFF
--- a/config/base.edn
+++ b/config/base.edn
@@ -11,7 +11,6 @@
                                "http://localhost:3449"}}
  :github {:client-id #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_GITHUB_CLIENT_ID"
           :client-secret #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_GITHUB_CLIENT_SECRET"
-          :signing-secret #immuconf/default "shhhhh....."
-          :web-client-redirect #immuconf/override "Specify the location of the web client"}
+          :signing-secret #immuconf/default "shhhhh....."}
  :aws {:access-key-id #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_AWS_ACCESS_KEY_ID"
        :secret-key #immuconf/override "Add to ~/.wombats/config.edn or as WOMBATS_AWS_SECRET_KEY"}}

--- a/config/dev-ddb.edn
+++ b/config/dev-ddb.edn
@@ -1,5 +1,4 @@
 {:datomic {:uri "datomic:ddb://us-east-1/wombats/dev"
            :requires-auth true}
  :pedestal {:port 8888
-            :container-options {:ssl? false}}
- :github {:web-client-redirect "http://localhost:3449"}}
+            :container-options {:ssl? false}}}

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -1,5 +1,4 @@
 {:datomic {:uri "datomic:free://localhost:4334/wombats-dev"
            :requires-auth false}
  :pedestal {:port 8888
-            :container-options {:ssl? false}}
- :github {:web-client-redirect "http://localhost:3449"}}
+            :container-options {:ssl? false}}}

--- a/config/qa-ddb.edn
+++ b/config/qa-ddb.edn
@@ -1,5 +1,4 @@
 {:datomic {:uri "datomic:ddb://us-east-1/wombats/qa"
            :requires-auth true}
  :pedestal {:port 8888
-            :container-options {:ssl? false}}
- :github {:web-client-redirect "http://qa.wombats.io"}}
+            :container-options {:ssl? false}}}

--- a/config/qa.edn
+++ b/config/qa.edn
@@ -1,5 +1,4 @@
 {:datomic {:uri "datomic:ddb://us-east-1/wombats/qa"
            :requires-auth false}
  :pedestal {:port 8888
-            :container-options {:ssl? false}}
- :github {:web-client-redirect "http://localhost:3449"}}
+            :container-options {:ssl? false}}}

--- a/src/wombats/handlers/auth.clj
+++ b/src/wombats/handlers/auth.clj
@@ -92,8 +92,6 @@
            web-client-redirect (remove-slash (get-in request [:headers "referer"]))
            failed-callback (redirect-home context web-client-redirect)]
 
-       (prn web-client-redirect)
-
        (if (= state signing-secret)
          (let [access-token @(get-access-token {:client_id client-id
                                                 :client_secret client-secret


### PR DESCRIPTION
## Problem 

Currently, the url you're redirected to after a Github auth is hardcoded in the api's config. This means that `dev.womats.io` always redirects to `localhost`, and that netlify builds will always redirect to either `localhost` or `qa.wombats.io`. 

## Solution

With this change, I changed how the github callback works in the api so that it redirects back to the referer (instead of requiring the config variable). 

I tested it on various ports and it seems to work. This addresses issue #202.