### PR TITLE
Feature/#149 smoke

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -131,6 +131,14 @@
   (-> (build-connection-string)
       refresh-db!))
 
+(deftask refresh-qa-ddb
+  "Resets the dev dynamo db"
+  []
+  (System/setProperty "APP_ENV" "qa-ddb")
+
+  (-> (build-connection-string)
+      refresh-db!))
+
 (deftask refresh-db
   "resets the database"
   []

--- a/resources/datomic/schema.edn
+++ b/resources/datomic/schema.edn
@@ -157,7 +157,7 @@
   :db/doc         "How much damage does a shot cause in arena configuration"}
 
  {:db/id          #db/id [:db.part/db]
-  :db/ident       :arena/smoke-duraition
+  :db/ident       :arena/smoke-duration
   :db/valueType   :db.type/long
   :db/cardinality :db.cardinality/one
   :db/doc         "How long does smoke persist in arena configuration"}
@@ -445,6 +445,12 @@
   :db/valueType   :db.type/long
   :db/cardinality :db.cardinality/one
   :db/doc         "Number of shots that found target"}
+
+ {:db/id          #db/id [:db.part/db]
+  :db/ident       :stats/smoke-bombs-thrown
+  :db/valueType   :db.type/long
+  :db/cardinality :db.cardinality/one
+  :db/doc         "Number of smoke bombs thrown"}
 
  {:db/id          #db/id [:db.part/db]
   :db/ident       :stats/number-of-moves

--- a/src/wombats/arena/utils.clj
+++ b/src/wombats/arena/utils.clj
@@ -99,6 +99,13 @@
     (assoc-in arena [y x :meta] new-meta)
     arena))
 
+(defn update-cell-metadata-with
+  "udpates a cells metadata with a given function"
+  [arena [x y] update-fn]
+  (if (coords-inbounds? [x y] arena)
+    (update-in arena [y x :meta] update-fn)
+    arena))
+
 (defn- generate-random-coords
   "generates random coordinates from a given dimension set"
   [[x y]]

--- a/src/wombats/arena/utils.clj
+++ b/src/wombats/arena/utils.clj
@@ -100,7 +100,7 @@
     arena))
 
 (defn update-cell-metadata-with
-  "udpates a cells metadata with a given function"
+  "updates a cells metadata with a given function"
   [arena [x y] update-fn]
   (if (coords-inbounds? [x y] arena)
     (update-in arena [y x :meta] update-fn)

--- a/src/wombats/daos/arena.clj
+++ b/src/wombats/daos/arena.clj
@@ -60,7 +60,7 @@
                              :arena/width width
                              :arena/height height
                              :arena/shot-damage shot-damage
-                             :arena/smoke-duraition smoke-duration
+                             :arena/smoke-duration smoke-duration
                              :arena/food food
                              :arena/poison poison
                              :arena/stone-walls stone-walls

--- a/src/wombats/daos/game.clj
+++ b/src/wombats/daos/game.clj
@@ -219,6 +219,7 @@
                        :stats/wood-barriers-hit 0
                        :stats/shots-fired 0
                        :stats/shots-hit 0
+                       :stats/smoke-bombs-thrown 0
                        :stats/number-of-moves 0
                        :stats/number-of-smoke-deploys 0}
             stats-link-to-game-trx {:db/id game-eid

--- a/src/wombats/game/decisions/helpers.clj
+++ b/src/wombats/game/decisions/helpers.clj
@@ -6,8 +6,14 @@
 
 (defn get-decision-maker-orientation
   [decision-maker-state]
-  (:orientation (get-decision-maker-contents)))
+  (:orientation (get-decision-maker-contents decision-maker-state)))
 
 (defn get-decision-maker-coords
   [decision-maker-state]
   (get-in decision-maker-state [:decision-maker :coords]))
+
+(defn get-arena-dimensions
+  [game-state]
+  (let [{width :arena/width
+         height :arena/height} (:arena-config game-state)]
+    [width height]))

--- a/src/wombats/game/decisions/shoot.clj
+++ b/src/wombats/game/decisions/shoot.clj
@@ -20,8 +20,8 @@
 (defn- get-shot-metadata
   [shooter]
   {:type :shot
-   :shooter-id (:uuid shooter)
-   :color (get shooter :color "#000000")
+   :owner-id (:uuid shooter)
+   :color (get shooter :color "black")
    :orientation (:orientation shooter)
    :decay 1})
 

--- a/src/wombats/game/decisions/smoke.clj
+++ b/src/wombats/game/decisions/smoke.clj
@@ -1,0 +1,89 @@
+(ns wombats.game.decisions.smoke
+  (:require [wombats.game.decisions.helpers :as dh]
+            [wombats.game.utils :as gu]
+            [wombats.arena.utils :as au]))
+
+(defn- get-smoked-coords
+  "Return a collection of coords that should be smokescreened given a central starting point"
+  [coords arena-dims]
+  (conj (map #(gu/adjust-coords coords % arena-dims)
+             (range 8))
+        coords))
+
+(defn- calculate-throw-direction
+  "determines the direction smoke should be thrown based off of the
+  decision makers orientation and the specified throw direction"
+  [decision-maker-orientation throw-direction]
+  (condp = throw-direction
+    :forward decision-maker-orientation
+    :right (mod (+ decision-maker-orientation 2) 8)
+    :backward (mod (+ decision-maker-orientation 4) 8)
+    :left (mod (- decision-maker-orientation 2) 8)
+    nil))
+
+(defn- get-smoke-metadata
+  "determines the metadata to display in the arena"
+  [{{smoke-duration :arena/smoke-duration} :arena-config}
+   decision-maker-state]
+  (let [decision-maker (dh/get-decision-maker-contents decision-maker-state)]
+    {:type :smoke
+     :owner-id (:uuid decision-maker)
+     :color (get decision-maker :color "black")
+     :decay smoke-duration}))
+
+(defn- calculate-smoke-origin
+  "calculates the origin cell of the smoke"
+  [decision-maker-state smoke-direction arena-dimensions]
+  (let [decision-maker-coords (dh/get-decision-maker-coords decision-maker-state)
+        decision-maker-orientation (dh/get-decision-maker-orientation decision-maker-state)
+        decision-maker-contents (dh/get-decision-maker-contents decision-maker-state)
+        throw-direction (calculate-throw-direction (gu/orientation-to-direction decision-maker-orientation)
+                                                   smoke-direction)]
+    (if throw-direction
+      (gu/adjust-coords decision-maker-coords
+                        throw-direction
+                        arena-dimensions 2)
+      decision-maker-coords)))
+
+(defn- update-arena
+  "add the smoke metatdata to the arena"
+  [game-state smoke-coords smoke-metadata]
+
+  (reduce (fn [game-state-acc smoke-coord]
+            (update-in game-state-acc
+                       [:frame :frame/arena]
+                       #(au/update-cell-metadata-with %
+                                                      smoke-coord
+                                                      (fn [existing-metadata]
+                                                        (conj existing-metadata
+                                                              smoke-metadata)))))
+          game-state
+          smoke-coords))
+
+(defn- update-player-stats
+  "update the players stats"
+  [game-state decision-maker-state]
+
+  (let [decision-maker (dh/get-decision-maker-contents decision-maker-state)]
+    (if (= (:type decision-maker) :wombat)
+      (-> game-state
+          (update-in [:players (:uuid decision-maker) :stats]
+                     (fn [stats]
+                       (update stats :stats/smoke-bombs-thrown inc))))
+      game-state)))
+
+(defn smoke
+  [game-state
+   metadata
+   decision-maker-state]
+
+  (let [arena-dimensions (dh/get-arena-dimensions game-state)
+        smoke-direction (keyword (or (:direction metadata) "drop"))
+        smoke-origin (calculate-smoke-origin decision-maker-state
+                                             smoke-direction
+                                             arena-dimensions)
+        smoke-coords (get-smoked-coords smoke-origin arena-dimensions)
+        smoke-metadata (get-smoke-metadata game-state decision-maker-state)]
+    (-> game-state
+        (update-arena smoke-coords smoke-metadata)
+        (update-player-stats decision-maker-state))))

--- a/src/wombats/game/decisions/smoke.clj
+++ b/src/wombats/game/decisions/smoke.clj
@@ -14,7 +14,7 @@
   "determines the direction smoke should be thrown based off of the
   decision makers orientation and the specified throw direction"
   [decision-maker-orientation throw-direction]
-  (condp = throw-direction
+  (case throw-direction
     :forward decision-maker-orientation
     :right (mod (+ decision-maker-orientation 2) 8)
     :backward (mod (+ decision-maker-orientation 4) 8)
@@ -42,6 +42,7 @@
     (if throw-direction
       (gu/adjust-coords decision-maker-coords
                         throw-direction
+                        ;; TODO Pull from config smoke-radius + 1
                         arena-dimensions 2)
       decision-maker-coords)))
 

--- a/src/wombats/game/occlusion.clj
+++ b/src/wombats/game/occlusion.clj
@@ -35,11 +35,17 @@
   #{:wood-barrier
     :steel-barrier})
 
+(defn- contains-occluding-metadata
+  [metadata]
+  (let [types (map #(:type %) metadata)]
+    (contains? types :smoke)))
+
 (defn- is-non-transparent-cell?
   "Determines if a cell is transparent"
   [cell non-transparent-types]
-  ;; TODO add smoke check here
-  (contains? non-transparent-types (get-in cell [:contents :type])))
+
+  (or (contains? non-transparent-types (get-in cell [:contents :type]))
+      (contains-occluding-metadata (:meta cell))))
 
 (defn- get-non-transparent-set
   "Returns a set of coordinates that cause occlusion"

--- a/src/wombats/game/occlusion.clj
+++ b/src/wombats/game/occlusion.clj
@@ -37,7 +37,7 @@
 
 (defn- contains-occluding-metadata
   [metadata]
-  (let [types (map #(:type %) metadata)]
+  (let [types (vec (map #(:type %) metadata))]
     (contains? types :smoke)))
 
 (defn- is-non-transparent-cell?

--- a/src/wombats/game/processor.clj
+++ b/src/wombats/game/processor.clj
@@ -8,7 +8,8 @@
             [wombats.arena.utils :as au]
             [wombats.game.decisions.turn :refer [turn]]
             [wombats.game.decisions.move :refer [move]]
-            [wombats.game.decisions.shoot :refer [shoot]])
+            [wombats.game.decisions.shoot :refer [shoot]]
+            [wombats.game.decisions.smoke :refer [smoke]])
 
   (:import [com.amazonaws.auth
             BasicAWSCredentials]
@@ -170,8 +171,8 @@
                                       ;;       to nil on error
                                       :saved-state (or response-state
                                                        (:saved-state decision-maker))
-                                      :error user-code-stacktrace}
-                                     response-command))]
+                                      :error user-code-stacktrace
+                                      :command response-command}))]
                    (merge decision-makers {uuid decision-maker-update})))))
 
      game-state
@@ -194,7 +195,8 @@
 (def ^:private command-map
   {:turn turn
    :move move
-   :shoot shoot})
+   :shoot shoot
+   :smoke smoke})
 
 (defn- get-command
   "Returns the request command handler or an identity function if none exist"

--- a/src/wombats/game/zakano_code.clj
+++ b/src/wombats/game/zakano_code.clj
@@ -2,16 +2,20 @@
 
 (def zakano-fn
   "(fn [state time-left]
-     (def turn-directions [:right :left :about-face])
+  (def turn-directions [:right :left :about-face])
+  (def smoke-directions [:forward :backward :left :right :drop])
 
-     (let [command-options [(repeat 10 {:command {:action :move
-                                                  :metadata {}}})
-                            (repeat 2 {:command {:action :turn
-                                                 :metadata {:direction (rand-nth turn-directions)}}})
-                            (repeat 4 {:command {:action :shoot
-                                                 :metadata {}}})]]
-       {:command (rand-nth (flatten command-options))
-        :state {:test true}}))")
+  (let [command-options [(repeat 10 {:action :move
+                                     :metadata {}})
+                         (repeat 2 {:action :turn
+                                    :metadata {:direction (rand-nth turn-directions)}})
+                         (repeat 4 {:action :shoot
+                                      :metadata {}})
+                         (repeat 3 {:action :smoke
+                                    :metadata {:direction (rand-nth smoke-directions)}})]]
+
+    {:command (rand-nth (flatten command-options))
+       :state {}}))")
 
 (defn get-zakano-code
   []


### PR DESCRIPTION
## Feature Smoke

#### Background
Smoke is an action that allows wombats to hide behind cover from enemies. All players cannot see through smoke which is reflected in the arena maps they receive during their turn. 

players can throw smoke in any direction or drop it straight down. 

```clj
(def smoke-directions [:forward :backward :left :right :drop])

{:action :smoke
  :metadata {:direction (rand-nth smoke-directions)}}
```