### PR TITLE
Port Interior Wall Logic

### DIFF
--- a/resources/datomic/schema.edn
+++ b/resources/datomic/schema.edn
@@ -175,10 +175,10 @@
   :db/doc         "Number of poison elements in arena configuration"}
 
  {:db/id          #db/id [:db.part/db]
-  :db/ident       :arena/stone-walls
+  :db/ident       :arena/steel-walls
   :db/valueType   :db.type/long
   :db/cardinality :db.cardinality/one
-  :db/doc         "Number of stone wall elements in arena configuration"}
+  :db/doc         "Number of steel wall elements in arena configuration"}
 
  {:db/id          #db/id [:db.part/db]
   :db/ident       :arena/wood-walls

--- a/src/wombats/arena/core.clj
+++ b/src/wombats/arena/core.clj
@@ -2,12 +2,6 @@
   (:require [wombats.arena.utils :as a-utils]
             [wombats.game.utils :as g-utils]))
 
-;; Cell structure
-;;
-;; {:contents {:type keyword
-;;             :uuid xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx
-;;  :meta [metadata]}
-
 (defn- add-to-arena
   "Adds item(s) randomly to an arena"
   [{:keys [config arena] :as arena-map} item amount]
@@ -18,20 +12,22 @@
 (defn- add-perimeter
   "Places block walls contiguously along the border of the arena"
   [{:keys [config arena] :as arena-map}]
-  (let [{dimx :arena/width
-         dimy :arena/height} config
-        wall (merge (:wood-barrier a-utils/arena-items)
-                    ;; TODO Pull from config
-                    {:hp 30})
-        xform (map-indexed (fn [y row]
-                             (if (#{0 (dec dimy)} y)
-                               (vec (map #(assoc % :contents (a-utils/ensure-uuid wall)) row))
-                               (-> (vec row)
-                                   (assoc-in [0 :contents] (a-utils/ensure-uuid wall))
-                                   (assoc-in [(dec dimx) :contents] (a-utils/ensure-uuid wall))))))]
-    (assoc arena-map
-           :arena
-           (vec (sequence xform arena)))))
+  (if (:arena/perimeter config)
+    (let [{dimx :arena/width
+           dimy :arena/height} config
+          wall (merge (:wood-barrier a-utils/arena-items)
+                      ;; TODO Pull from config
+                      {:hp 30})
+          xform (map-indexed (fn [y row]
+                               (if (#{0 (dec dimy)} y)
+                                 (vec (map #(assoc % :contents (a-utils/ensure-uuid wall)) row))
+                                 (-> (vec row)
+                                     (assoc-in [0 :contents] (a-utils/ensure-uuid wall))
+                                     (assoc-in [(dec dimx) :contents] (a-utils/ensure-uuid wall))))))]
+      (assoc arena-map
+             :arena
+             (vec (sequence xform arena))))
+    arena-map))
 
 (defn- generate-empty-arena
   "creates empty arena"
@@ -47,18 +43,127 @@
                                            {:contents (a-utils/ensure-uuid open-space)
                                             :meta []}))))))))
 
+(let [moves {:n [ 0 -1] :ne [ 1 -1] :e [ 1  0] :se [ 1  1]
+             :s [ 0  1] :sw [-1  1] :w [-1  0] :nw [-1 -1]}]
+  (defn- move
+    "Return new coordinates for a move from coordinates in direction"
+    [coordinates direction [m n :as dimensions] & {:keys [oob] :or {oob :wrap}}]
+    {:pre [(moves direction)]
+     :post [(let [[x y] %] (and (integer? x) (integer? y)))]}
+    (let [oob? (fn [[x y]] (not (and (<= 0 x (dec m)) (<= 0 y (dec n)))))
+          coordinates' (mapv + coordinates (moves direction))]
+      (if (oob? coordinates')
+        (case oob
+          :return coordinates
+          :wrap (g-utils/wrap-coords coordinates' dimensions))
+        coordinates'))))
+
+
+(defn- block?
+  [arena next-cell]
+  (let [cell-contents (g-utils/get-content-at-coords next-cell arena)]
+    (contains? #{:wood-barrier
+                 :steel-barrier}
+               (:type cell-contents))))
+
+(defn- wall-adjacent?
+  "Is the given coordinate pair adjacent to a wall?"
+  [coordinates arena dimensions]
+  (some (fn [d]
+          (let [next-cell (move coordinates d dimensions)]
+            (when (block? arena next-cell)
+              [d next-cell])))
+        (list :n :e :s :w)))
+
+(defn- place-wall
+  "place a single contiguous block wall of max length l starting at coordinates start in direction d"
+  [starting-cell
+   walls-remaining
+   direction
+   arena-dimensions
+   arena
+   wall]
+  {:pre [((complement neg?) walls-remaining)
+         (#{:n :e :s :w} direction)]}
+  (loop [arena arena
+         l' 0
+         head starting-cell
+         anchor-count 0]
+    (let [anchor-count (+ anchor-count (if (wall-adjacent? starting-cell
+                                                           arena
+                                                           arena-dimensions) 1 0))]
+      (if (and (< l' walls-remaining)
+               (a-utils/pos-open? head arena) (< anchor-count 2))
+        (let [arena' (a-utils/update-cell-contents arena
+                                                   head
+                                                   (a-utils/ensure-uuid wall))
+              head' (move head
+                          direction
+                          arena-dimensions
+                          :oob
+                          :return)]
+          (recur arena' (inc l') head' anchor-count))
+        [l' arena]))))
+
+(defn- get-wall-contents
+  [wall-type]
+  (case wall-type
+    :arena/wood-walls (merge (:wood-barrier a-utils/arena-items)
+                             {;; TODO Pull from config
+                              :hp 20})
+    :arena/steel-walls (merge (:steel-barrier a-utils/arena-items)
+                              {;; TODO Pull from config
+                               :hp 200})))
+
+(defn- place-walls
+  "places walls in an organized structures around the arena"
+  [{:keys [arena config] :as arena-map}
+   wall-type]
+
+  (let [wall-count (wall-type config)
+        arena-dimensions (a-utils/get-arena-dimensions arena)
+        arena-update
+        (loop [arena arena
+               walls-remaining (int wall-count)
+               tries 50]
+          (cond
+            (and (pos? tries)
+                 (pos? walls-remaining))
+            (let [starting-cell (a-utils/find-random-open-space arena)
+                  direction (rand-nth [:n :s :e :w])
+                  [walls-placed arena'] (place-wall starting-cell
+                                                    walls-remaining
+                                                    direction
+                                                    arena-dimensions
+                                                    arena
+
+                                                    (get-wall-contents wall-type))]
+              (recur arena'
+                     (- walls-remaining walls-placed)
+                     (dec tries)))
+
+            (pos? tries)
+            arena
+
+            :else
+            arena))]
+    (assoc arena-map :arena arena-update)))
+
 (defn generate-arena
   [{:keys [:arena/food
            :arena/poison
            :arena/zakano] :as arena-config}]
-  (:arena
-   (cond-> {:config arena-config
-            :arena nil}
-     true (generate-empty-arena)
-     (:arena/perimeter arena-config) (add-perimeter)
-     true (add-to-arena (:food a-utils/arena-items) food)
-     true (add-to-arena (:poison a-utils/arena-items) poison)
-     true (add-to-arena (merge (:zakano a-utils/arena-items)
-                               {:orientation (g-utils/rand-orientation)
-                                ;; TODO Add to arena config
-                                :hp 50}) zakano))))
+
+  (-> {:config arena-config
+       :arena nil}
+      (generate-empty-arena)
+      (add-perimeter)
+      (place-walls :arena/wood-walls)
+      (place-walls :arena/steel-walls)
+      (add-to-arena (:food a-utils/arena-items) food)
+      (add-to-arena (:poison a-utils/arena-items) poison)
+      (add-to-arena (merge (:zakano a-utils/arena-items)
+                           {:orientation (g-utils/rand-orientation)
+                            ;; TODO Add to arena config
+                            :hp 50}) zakano)
+      (:arena)))

--- a/src/wombats/arena/utils.clj
+++ b/src/wombats/arena/utils.clj
@@ -112,7 +112,7 @@
   [(rand-int x)
    (rand-int y)])
 
-(defn- find-random-open-space
+(defn find-random-open-space
   "returns the coordinates for a random open space in a given arena"
   [arena]
   (let [arena-dimensions (get-arena-dimensions arena)]

--- a/src/wombats/daos/arena.clj
+++ b/src/wombats/daos/arena.clj
@@ -47,7 +47,7 @@
               :arena/smoke-duration
               :arena/food
               :arena/poison
-              :arena/stone-walls
+              :arena/steel-walls
               :arena/wood-walls
               :arena/zakano
               :arena/perimeter]}]
@@ -63,7 +63,7 @@
                              :arena/smoke-duration smoke-duration
                              :arena/food food
                              :arena/poison poison
-                             :arena/stone-walls stone-walls
+                             :arena/steel-walls steel-walls
                              :arena/wood-walls wood-walls
                              :arena/zakano zakano
                              :arena/perimeter perimeter}])))

--- a/src/wombats/game/utils.clj
+++ b/src/wombats/game/utils.clj
@@ -70,7 +70,7 @@
      {:coords [x y]
       :item val})))
 
-(defn- wrap-coords
+(defn wrap-coords
   "Wraps out-of-bounds coordinates (zero-based) to opposite edge of m x n arena"
   [[x y] [m n]]
   {:pre [(integer? x) (integer? y) (pos? m) (pos? n)]

--- a/src/wombats/handlers/arena.clj
+++ b/src/wombats/handlers/arena.clj
@@ -6,14 +6,14 @@
 
 (def ^:private arena-body-sample
   #:arena{:name "Arena Name"
-          :width 50
-          :height 50
+          :width 20
+          :height 20
           :shot-damage 10
           :smoke-duration 3
           :food 10
           :poison 10
-          :stone-walls 50
-          :wood-walls 50
+          :steel-walls 10
+          :wood-walls 10
           :zakano 4
           :perimeter true})
 

--- a/test/wombats/test/arena/core.clj
+++ b/test/wombats/test/arena/core.clj
@@ -1,0 +1,79 @@
+(ns wombats.test.arena.core
+  (:require [clojure.test :refer :all]
+            [wombats.arena.utils :as a-utils]
+            [wombats.game.utils :as g-utils]
+            [wombats.arena.core :as a-core]))
+
+(def wide-arena-configuration
+  #:arena {:food 0
+           :poison 0
+           :zakano 0
+           :perimeter false
+           :wood-walls 0
+           :steel-walls 0
+           :width 100
+           :height 10})
+
+(def tall-arena-configuration
+  #:arena {:food 0
+           :poison 0
+           :zakano 0
+           :perimeter false
+           :wood-walls 0
+           :steel-walls 0
+           :width 10
+           :height 100})
+
+(def empty-arena-configuration
+  #:arena{:food 0
+          :poison 0
+          :zakano 0
+          :perimeter false
+          :wood-walls 0
+          :steel-walls 0
+          :width 10
+          :height 10})
+
+(def perimeter-arena-configuration
+  #:arena{:food 0
+          :poison 0
+          :zakano 0
+          :perimeter true
+          :wood-walls 0
+          :steel-walls 0
+          :width 10
+          :height 10})
+
+(deftest generate-arena
+  (testing "passing a valid configuration map will create an arena of the proper dimensions"
+    (is (= (-> (a-core/generate-arena empty-arena-configuration)
+               (a-utils/get-arena-dimensions))
+           [10 10]))
+    (is (= (-> (a-core/generate-arena wide-arena-configuration)
+               (a-utils/get-arena-dimensions))
+           [100 10]))
+    (is (= (-> (a-core/generate-arena tall-arena-configuration)
+               (a-utils/get-arena-dimensions))
+           [10 100])))
+
+  (testing "passing a vaild configuration map will genereate an empty arena if no values are present"
+    (is (= (->> (a-core/generate-arena empty-arena-configuration)
+               (flatten)
+               (filter #(= (get-in % [:contents :type]) :open))
+               (count))
+           100)))
+  (testing "passing the perimeter configuration value will add a wood wall perimeter"
+    (is (= (->> (a-core/generate-arena perimeter-arena-configuration)
+                (flatten)
+                (filter #(= (get-in % [:contents :type]) :wood-barrier))
+                (count))
+           36))
+    (is (let [arena (a-core/generate-arena perimeter-arena-configuration)
+              top-left (:type (g-utils/get-content-at-coords [0 0] arena))
+              top-right (:type (g-utils/get-content-at-coords [9 0] arena))
+              bottom-left (:type (g-utils/get-content-at-coords [0 9] arena))
+              bottom-right (:type (g-utils/get-content-at-coords [9 9] arena))]
+          (and (= :wood-barrier top-left)
+               (= :wood-barrier top-right)
+               (= :wood-barrier bottom-right)
+               (= :wood-barrier bottom-right))))))


### PR DESCRIPTION
## Feature Interior Wall Generation

- Port over interior wall logic and update it to support new structure
- Add initial tests for arena generation

This PR will generate both wood and steel barriers on the interior of the arena. If no perimeter is present, it will also use those spaces to generate barriers.   