### PR TITLE
Feature #90 Wall Deterioration

### DIFF
--- a/resources/datomic/schema.edn
+++ b/resources/datomic/schema.edn
@@ -181,16 +181,40 @@
   :db/doc         "Number of steel wall elements in arena configuration"}
 
  {:db/id          #db/id [:db.part/db]
+  :db/ident       :arena/steel-wall-hp
+  :db/valueType   :db.type/long
+  :db/cardinality :db.cardinality/one
+  :db/doc         "HP allocated to steel walls"}
+
+ {:db/id          #db/id [:db.part/db]
   :db/ident       :arena/wood-walls
   :db/valueType   :db.type/long
   :db/cardinality :db.cardinality/one
   :db/doc         "Number of wood wall elements in arena configuration"}
 
  {:db/id          #db/id [:db.part/db]
+  :db/ident       :arena/wood-wall-hp
+  :db/valueType   :db.type/long
+  :db/cardinality :db.cardinality/one
+  :db/doc         "HP allocated to wood walls"}
+
+ {:db/id          #db/id [:db.part/db]
   :db/ident       :arena/zakano
   :db/valueType   :db.type/long
   :db/cardinality :db.cardinality/one
   :db/doc         "Number of Zakano elements in arena configuration"}
+
+ {:db/id          #db/id [:db.part/db]
+  :db/ident       :arena/zakano-hp
+  :db/valueType   :db.type/long
+  :db/cardinality :db.cardinality/one
+  :db/doc         "HP allocated to a Zakano"}
+
+ {:db/id          #db/id [:db.part/db]
+  :db/ident       :arena/wombat-hp
+  :db/valueType   :db.type/long
+  :db/cardinality :db.cardinality/one
+  :db/doc         "HP allocated to a Wombat"}
 
  {:db/id          #db/id [:db.part/db]
   :db/ident       :arena/perimeter

--- a/src/wombats/daos/arena.clj
+++ b/src/wombats/daos/arena.clj
@@ -48,8 +48,12 @@
               :arena/food
               :arena/poison
               :arena/steel-walls
+              :arena/steel-wall-hp
               :arena/wood-walls
+              :arena/wood-wall-hp
               :arena/zakano
+              :arena/zakano-hp
+              :arena/wombat-hp
               :arena/perimeter]}]
 
     (ensure-name-availability conn name)
@@ -64,8 +68,12 @@
                              :arena/food food
                              :arena/poison poison
                              :arena/steel-walls steel-walls
+                             :arena/steel-wall-hp steel-wall-hp
                              :arena/wood-walls wood-walls
+                             :arena/wood-wall-hp wood-wall-hp
                              :arena/zakano zakano
+                             :arena/zakano-hp zakano-hp
+                             :arena/wombat-hp wombat-hp
                              :arena/perimeter perimeter}])))
 
 (defn update-arena

--- a/src/wombats/game/finalizers.clj
+++ b/src/wombats/game/finalizers.clj
@@ -11,11 +11,35 @@
                             [] meta)]
     (assoc cell :meta meta-update)))
 
-(defn- update-metadata-decay
-  [game-state]
+(defn- update-deterioration
+  "Determines the deterioration level and applies it to the element"
+  [{:keys [contents] :as cell} max-hp]
+  (let [percent-deteriorated (-> (:hp contents)
+                                 (/ max-hp)
+                                 (float))
+        deterioration-key (condp >= percent-deteriorated
+                            0.4 :high
+                            0.7 :medium
+                            :low)]
+    (assoc-in cell [:contents :deterioration-level] deterioration-key)))
+
+(defn- update-cell-deterioration-level
+  [cell arena-config]
+  (case (get-in cell [:contents :type])
+    :wombat (update-deterioration cell (:arena/wombat-hp arena-config))
+    :zakano (update-deterioration cell (:arena/zakano-hp arena-config))
+    :wood-barrier (update-deterioration cell (:arena/wood-wall-hp arena-config))
+    :steel-barrier (update-deterioration cell (:arena/steel-wall-hp arena-config))
+    cell))
+
+(defn- update-arena-data
+  "Maps over each cell updating attributes like metadata decay and damage levels"
+  [{:keys [arena-config] :as game-state}]
   (let [updated-arena
         (vec (map (fn [row]
-                    (vec (map update-cell-metadata row)))
+                    (vec (map #(-> %
+                                   (update-cell-metadata)
+                                   (update-cell-deterioration-level arena-config)) row)))
                   (get-in game-state [:frame :frame/arena])))]
     (assoc-in game-state [:frame :frame/arena] updated-arena)))
 
@@ -23,7 +47,7 @@
   [game-state]
   ;; TODO #152
   (-> game-state
-      (update-metadata-decay)))
+      (update-arena-data)))
 
 (defn finalize-game
   [game-state]

--- a/src/wombats/handlers/arena.clj
+++ b/src/wombats/handlers/arena.clj
@@ -13,8 +13,12 @@
           :food 10
           :poison 10
           :steel-walls 10
+          :steel-wall-hp 500
           :wood-walls 10
-          :zakano 4
+          :wood-wall-hp 30
+          :zakano 5
+          :zakano-hp 50
+          :wombat-hp 200
           :perimeter true})
 
 ;; Swagger Parameters
@@ -106,9 +110,13 @@
 (s/def :arean/smoke-duration #(instance? Long %))
 (s/def :arena/food #(instance? Long %))
 (s/def :arena/poison #(instance? Long %))
-(s/def :arena/stone-walls #(instance? Long %))
+(s/def :arena/steel-walls #(instance? Long %))
+(s/def :arena/steel-wall-hp #(instance? Long %))
 (s/def :arena/wood-walls #(instance? Long %))
+(s/def :arena/wood-wall-hp #(instance? Long %))
 (s/def :arena/zakano #(instance? Long %))
+(s/def :arena/zakano-hp #(instance? Long %))
+(s/def :arena/wombat-hp #(instance? Long %))
 (s/def :arena/perimeter boolean?)
 
 (s/def ::new-arena (s/keys :req [:arena/name
@@ -117,7 +125,14 @@
                                  :arena/shot-damage
                                  :arena/smoke-duration
                                  :arena/food
-                                 :arena/poison]))
+                                 :arena/poison
+                                 :arena/wombat-hp
+                                 :arena/zakano
+                                 :arena/zakano-hp
+                                 :arena/wood-walls
+                                 :arena/wood-wall-hp
+                                 :arena/steel-walls
+                                 :arena/steel-wall-hp]))
 
 (s/def ::update-arena (s/merge ::new-arena
                                (s/keys :req [:arena/id])))


### PR DESCRIPTION
## Feature

Walls can receive damage and after enough damage has occurred, the wall is required to visually change. 

To accomplish this we are applying the `:deterioration-level` parameter to the `contents` of the cell. 

I added this process to the `finalize-frame` pipeline so the arena is scanned only once while making these updates. 

Note: deterioration levels will be applied to anything with hp. This will allow us to support features in the future like (injured wombats / Zakano) ## Feature

### Warning

This PR does require a database refresh