### PR TITLE
push frame updates to datomic

### DIFF
--- a/resources/datomic/schema.edn
+++ b/resources/datomic/schema.edn
@@ -480,10 +480,4 @@
   :db/ident       :stats/number-of-moves
   :db/valueType   :db.type/long
   :db/cardinality :db.cardinality/one
-  :db/doc         "Number of moves"}
-
- {:db/id          #db/id [:db.part/db]
-  :db/ident       :stats/number-of-smoke-deploys
-  :db/valueType   :db.type/long
-  :db/cardinality :db.cardinality/one
-  :db/doc         "Number of smoke deploys"}]
+  :db/doc         "Number of moves"}]

--- a/src/wombats/daos/game.clj
+++ b/src/wombats/daos/game.clj
@@ -300,7 +300,8 @@
                      :frame/frame-number frame-number
                      :frame/arena (nippy/freeze arena)}
           stats-trxs (vec (map (fn [[_ {stats :stats}]]
-                                 stats) players))]
+                                 (assoc stats :stats/frame-number frame-number))
+                               players))]
       (d/transact-async conn (conj stats-trxs frame-trx)))))
 
 (defn- close-game-state

--- a/src/wombats/daos/game.clj
+++ b/src/wombats/daos/game.clj
@@ -220,8 +220,7 @@
                        :stats/shots-fired 0
                        :stats/shots-hit 0
                        :stats/smoke-bombs-thrown 0
-                       :stats/number-of-moves 0
-                       :stats/number-of-smoke-deploys 0}
+                       :stats/number-of-moves 0}
             stats-link-to-game-trx {:db/id game-eid
                                     :game/stats stats-tmpid}
             closed-trx {:db/id game-eid
@@ -294,14 +293,20 @@
   [conn]
   (fn [{:keys [:db/id
               :frame/arena
-              :frame/frame-number]}]
-    (d/transact-async conn [{:db/id id
-                             :frame/frame-number frame-number
-                             :frame/arena (nippy/freeze arena)}])))
+              :frame/frame-number]}
+      players]
+
+    (let [frame-trx {:db/id id
+                     :frame/frame-number frame-number
+                     :frame/arena (nippy/freeze arena)}
+          stats-trxs (vec (map (fn [[_ {stats :stats}]]
+                                 stats) players))]
+      (d/transact-async conn (conj stats-trxs frame-trx)))))
 
 (defn- close-game-state
   [conn]
   (fn [game-id]
+
     (d/transact-async conn [{:game/id game-id
                              :game/status :closed}])))
 

--- a/src/wombats/game/core.clj
+++ b/src/wombats/game/core.clj
@@ -3,7 +3,8 @@
             [wombats.game.finalizers :as f]
             [wombats.game.processor :as p]
             [wombats.arena.utils :as au]
-            [wombats.sockets.game :as game-sockets]))
+            [wombats.sockets.game :as game-sockets]
+            [wombats.daos.game :refer [update-frame-state]]))
 
 (defn- game-over?
   "End game condition"
@@ -14,12 +15,17 @@
   (= 50 (get-in game-state [:frame :frame/frame-number])))
 
 (defn- push-frame-to-clients
-  [game-state]
+  [{:keys [frame] :as game-state}]
 
   (game-sockets/broadcast-arena
    (:game-id game-state)
-   (get-in game-state [:frame :frame/arena]))
+   (:frame/arena frame))
 
+  game-state)
+
+(defn- push-frame-to-datomic
+  [{:keys [frame] :as game-state} datomic-conn]
+  ((update-frame-state datomic-conn) frame)
   game-state)
 
 (defn- add-player-scores
@@ -65,7 +71,7 @@
   [{:keys [frame] :as game-state} interval]
 
   ;; Pretty print the arena
-  #_(au/print-arena (:frame/arena frame))
+  (au/print-arena (:frame/arena frame))
 
   ;; Pretty print the full arena state
   #_(clojure.pprint/pprint (:frame/arena frame))
@@ -75,7 +81,7 @@
    (dissoc game-state :frame))
 
   ;; Pretty print everything
-  (clojure.pprint/pprint game-state)
+  #_(clojure.pprint/pprint game-state)
 
   ;; Print number of players
   #_(prn (str "Player Count: " (count (keys (:players game-state)))))
@@ -94,7 +100,7 @@
 
 (defn- game-loop
   "Game loop"
-  [game-state aws-credentials]
+  [game-state datomic-conn aws-credentials]
   (loop [current-game-state game-state]
     (if (game-over? current-game-state)
       current-game-state
@@ -106,15 +112,16 @@
           (timeout-frame 1000)
           (push-frame-to-clients)
           (push-stats-update-to-clients)
+          (push-frame-to-datomic datomic-conn)
           #_(frame-debugger 1000)
           (recur)))))
 
 
 (defn initialize-game
   "Main entry point for the game engine"
-  [game-state aws-credentials]
+  [game-state datomic-conn aws-credentials]
   (-> game-state
       (i/initialize-game)
-      (game-loop aws-credentials)
+      (game-loop datomic-conn aws-credentials)
       #_(frame-debugger 0)
-      (f/finalize-game)))
+      (f/finalize-game datomic-conn)))

--- a/src/wombats/game/core.clj
+++ b/src/wombats/game/core.clj
@@ -23,8 +23,8 @@
   game-state)
 
 (defn- push-frame-to-datomic
-  [{:keys [frame] :as game-state} update-frame]
-  (update-frame frame)
+  [{:keys [frame players] :as game-state} update-frame]
+  (update-frame frame players)
   game-state)
 
 (defn- close-out-game
@@ -75,7 +75,7 @@
   [{:keys [frame] :as game-state} interval]
 
   ;; Pretty print the arena
-  (au/print-arena (:frame/arena frame))
+  #_(au/print-arena (:frame/arena frame))
 
   ;; Pretty print the full arena state
   #_(clojure.pprint/pprint (:frame/arena frame))
@@ -86,6 +86,9 @@
 
   ;; Pretty print everything
   #_(clojure.pprint/pprint game-state)
+
+  ;; Print frame number
+  (prn (get-in game-state [:frame :frame/frame-number]))
 
   ;; Print number of players
   #_(prn (str "Player Count: " (count (keys (:players game-state)))))
@@ -113,11 +116,10 @@
           (p/source-decisions aws-credentials)
           (p/process-decisions)
           (f/finalize-frame)
-          (timeout-frame 1000)
+          (timeout-frame 500)
           (push-frame-to-clients)
           (push-stats-update-to-clients)
           (push-frame-to-datomic update-frame)
-          #_(frame-debugger 1000)
           (recur)))))
 
 
@@ -131,6 +133,5 @@
   (-> game-state
       (i/initialize-game)
       (game-loop update-frame aws-credentials)
-      #_(frame-debugger 0)
       (f/finalize-game)
       (close-out-game close-game)))

--- a/src/wombats/game/core.clj
+++ b/src/wombats/game/core.clj
@@ -4,7 +4,8 @@
             [wombats.game.processor :as p]
             [wombats.arena.utils :as au]
             [wombats.sockets.game :as game-sockets]
-            [wombats.daos.game :refer [update-frame-state]]))
+            [wombats.daos.game :refer [update-frame-state
+                                       close-game-state]]))
 
 (defn- game-over?
   "End game condition"
@@ -26,6 +27,12 @@
 (defn- push-frame-to-datomic
   [{:keys [frame] :as game-state} datomic-conn]
   ((update-frame-state datomic-conn) frame)
+  game-state)
+
+(defn- close-out-game
+  [{:keys [game-id] :as game-state}
+   datomic-conn]
+  ((close-game-state datomic-conn) game-id)
   game-state)
 
 (defn- add-player-scores
@@ -124,4 +131,5 @@
       (i/initialize-game)
       (game-loop datomic-conn aws-credentials)
       #_(frame-debugger 0)
-      (f/finalize-game datomic-conn)))
+      (f/finalize-game)
+      (close-out-game datomic-conn)))

--- a/src/wombats/game/finalizers.clj
+++ b/src/wombats/game/finalizers.clj
@@ -1,4 +1,5 @@
-(ns wombats.game.finalizers)
+(ns wombats.game.finalizers
+  (:require [wombats.daos.game :refer [close-game-state]]))
 
 (defn- update-cell-metadata
   [{:keys [meta] :as cell}]
@@ -45,11 +46,10 @@
 
 (defn finalize-frame
   [game-state]
-  ;; TODO #152
   (-> game-state
       (update-arena-data)))
 
 (defn finalize-game
-  [game-state]
-  ;; TODO #152
+  [{:keys [game-id] :as game-state} datomic-conn]
+  ((close-game-state datomic-conn) game-id)
   game-state)

--- a/src/wombats/game/finalizers.clj
+++ b/src/wombats/game/finalizers.clj
@@ -1,5 +1,4 @@
-(ns wombats.game.finalizers
-  (:require [wombats.daos.game :refer [close-game-state]]))
+(ns wombats.game.finalizers)
 
 (defn- update-cell-metadata
   [{:keys [meta] :as cell}]
@@ -50,6 +49,5 @@
       (update-arena-data)))
 
 (defn finalize-game
-  [{:keys [game-id] :as game-state} datomic-conn]
-  ((close-game-state datomic-conn) game-id)
+  [game-state]
   game-state)

--- a/src/wombats/game/zakano_code.clj
+++ b/src/wombats/game/zakano_code.clj
@@ -11,7 +11,7 @@
                                     :metadata {:direction (rand-nth turn-directions)}})
                          (repeat 4 {:action :shoot
                                       :metadata {}})
-                         (repeat 3 {:action :smoke
+                         (repeat 1 {:action :smoke
                                     :metadata {:direction (rand-nth smoke-directions)}})]]
 
     {:command (rand-nth (flatten command-options))


### PR DESCRIPTION
## Feature Persist Frame State

This feature will formate each frame after it has finished processing and save that state to datomic. After the game has finished, a transaction to update the game status is submitted and the game is transitioned to a closed state.