### PR TITLE
Update game query to return additional information

### DIFF
--- a/src/wombats/daos/game.clj
+++ b/src/wombats/daos/game.clj
@@ -68,7 +68,13 @@
 (defn get-games-by-eids
   [conn]
   (fn [game-eids]
-    (d/pull-many (d/db conn) '[* {:game/arena [:db/id *]}] game-eids)))
+    (d/pull-many
+     (d/db conn) '[*
+                   {:game/arena [:db/id *]}
+                   {:game/players [:db/id :player/color
+                                   {:player/user [:db/id :user/github-username]}
+                                   {:player/wombat [:db/id :wombat/name]}]}]
+     game-eids)))
 
 (defn get-game-by-id
   [conn]


### PR DESCRIPTION
### Problem

There is not enough information being passed back for each game to support designs / ux (users cannot determine which colors have been chosen)

### Solution

Return player information inside of the game query

- Add player color
- Add player github name
- Add player wombat name

Note: This information is only returned in game queries that filter (is game status or user id)

Example Payload

```edn
{:game/start-time
    #inst "2017-02-09T15:29:35.661-00:00"
  :game/id "2d5c4c6d-9dfd-4b89-a908-b08750a79dd6"
  :game/arena
    {:arena/steel-wall-hp 500
     :arena/name "Arena Name"
     :arena/perimeter true
     :arena/shot-damage 10
     :arena/smoke-duration 3
     :arena/zakano-hp 50
     :arena/poison 10
     :arena/food 10
     :arena/id "487ded25-c501-48b8-9273-9d7f68534ff8"
     :arena/zakano 5
     :arena/steel-walls 10
     :arena/wood-walls 10
     :arena/width 20
     :arena/wombat-hp 200
     :db/id 17592186045430
     :arena/wood-wall-hp 30
     :arena/height 20}
  :game/stats [{:db/id 17592186045830}]
  :game/status :closed
  :game/num-rounds 3
  :game/round-intermission 1200000
  :game/max-players 10
  :game/password ""
  :game/is-private false
  :db/id 17592186045827
  :game/frame {:db/id 17592186045826}
  :game/players
    [{:db/id 17592186045829
      :player/color "green"
      :player/user
        {:db/id 17592186045424
         :user/github-username "oconn"}
      :player/wombat
        {:db/id 17592186045824
         :wombat/name "Teddy"}}]
  :game/type :round
  :game/name "New Game 9"}
```