### PR TITLE
Game Play Information

### DIFF
--- a/src/wombats/daos/core.clj
+++ b/src/wombats/daos/core.clj
@@ -40,6 +40,7 @@
    :get-game-eids-by-player (game/get-game-eids-by-player conn)
    :get-games-by-eids (game/get-games-by-eids conn)
    :get-game-by-id (game/get-game-by-id conn)
+   :get-game-state-by-id (game/get-game-state-by-id conn)
    :get-player-from-game (game/get-player-from-game conn)
    :add-game (game/add-game conn)
    :retract-game (game/retract-game conn)

--- a/src/wombats/game/core.clj
+++ b/src/wombats/game/core.clj
@@ -1,6 +1,7 @@
 (ns wombats.game.core
   (:require [wombats.game.initializers :as i]
             [wombats.game.finalizers :as f]
+            [wombats.game.player-stats :refer [get-player-stats]]
             [wombats.game.processor :as p]
             [wombats.arena.utils :as au]
             [wombats.sockets.game :as game-sockets]))
@@ -36,7 +37,7 @@
   [game-state]
   (game-sockets/broadcast-stats
     (:game-id game-state)
-    (game-sockets/get-player-stats game-state))
+    (get-player-stats game-state))
   game-state)
 
 (defn frame-debugger

--- a/src/wombats/game/core.clj
+++ b/src/wombats/game/core.clj
@@ -32,41 +32,11 @@
   (close-game game-id)
   game-state)
 
-(defn- add-player-scores
-  [stats players]
-  (reduce
-   (fn [stats-acc [uuid {:keys [stats user wombat player]}]]
-     (let [score (:stats/score stats)
-           user (:user/github-username user)
-           wombat (:wombat/name wombat)
-           color (:player/color player)]
-       (assoc stats-acc uuid {:score score
-                              :username user
-                              :wombat-name wombat
-                              :color color})))
-   stats players))
-
-(defn- add-player-hp
-  [stats arena]
-  (let [player-ids (set (keys stats))]
-    (reduce
-     (fn [stats-acc cell]
-       (let [cell-uuid (get-in cell [:contents :uuid])]
-         (if (contains? player-ids cell-uuid)
-           (assoc-in stats-acc [cell-uuid :hp] (get-in cell [:contents :hp]))
-           stats-acc)))
-     stats (flatten arena))))
-
 (defn- push-stats-update-to-clients
   [game-state]
-  (let [player-stats (-> {}
-                         (add-player-scores (:players game-state))
-                         (add-player-hp (get-in game-state [:frame
-                                                            :frame/arena]))
-                         vals)]
-    (game-sockets/broadcast-stats
-     (:game-id game-state)
-     player-stats))
+  (game-sockets/broadcast-stats
+    (:game-id game-state)
+    (game-sockets/get-player-stats game-state))
   game-state)
 
 (defn frame-debugger

--- a/src/wombats/game/player_stats.clj
+++ b/src/wombats/game/player_stats.clj
@@ -1,0 +1,35 @@
+(ns wombats.game.player-stats)
+
+(defn- add-player-scores
+  [stats players]
+  (reduce
+   (fn [stats-acc [uuid {:keys [stats user wombat player]}]]
+     (let [score (:stats/score stats)
+           user (:user/github-username user)
+           wombat (:wombat/name wombat)
+           color (:player/color player)]
+       (assoc stats-acc uuid {:score score
+                              :username user
+                              :wombat-name wombat
+                              :color color})))
+   stats players))
+
+(defn- add-player-hp
+  [stats arena]
+  (let [player-ids (set (keys stats))]
+    (reduce
+     (fn [stats-acc cell]
+       (let [cell-uuid (get-in cell [:contents :uuid])]
+         (if (contains? player-ids cell-uuid)
+           (assoc-in stats-acc [cell-uuid :hp] (get-in cell [:contents :hp]))
+           stats-acc)))
+     stats (flatten arena))))
+
+(defn get-player-stats
+  "Returns stats from game-state"
+  [game-state]
+  (-> {}
+      (add-player-scores (:players game-state))
+      (add-player-hp (get-in game-state [:frame
+                                         :frame/arena]))
+      vals))

--- a/src/wombats/sockets/game.clj
+++ b/src/wombats/sockets/game.clj
@@ -157,11 +157,17 @@
   [datomic]
   (fn [{:keys [chan-id :user/id] :as socket-user}
       {:keys [game-id]}]
-    (let [player ((:get-player-from-game datomic) game-id id)]
+    (let [player ((:get-player-from-game datomic) game-id id)
+          game-state ((:get-game-state-by-id datomic) game-id)
+          arena (get-in game-state [:frame :frame/arena])]
+
       (swap! game-rooms
              assoc-in
              [game-id :players chan-id]
-             (assoc socket-user :color (:player/color player))))))
+             (assoc socket-user :color (:player/color player)))
+
+      ;; Sends the initial frame to the frontend
+      (broadcast-arena game-id arena))))
 
 (defn- leave-game
   [_]

--- a/src/wombats/sockets/game.clj
+++ b/src/wombats/sockets/game.clj
@@ -130,6 +130,42 @@
   [game-id chan-id]
   (:color (get-game-room-player game-id chan-id)))
 
+;; Player Stats Methods
+
+(defn- add-player-scores
+  [stats players]
+  (reduce
+   (fn [stats-acc [uuid {:keys [stats user wombat player]}]]
+     (let [score (:stats/score stats)
+           user (:user/github-username user)
+           wombat (:wombat/name wombat)
+           color (:player/color player)]
+       (assoc stats-acc uuid {:score score
+                              :username user
+                              :wombat-name wombat
+                              :color color})))
+   stats players))
+
+(defn- add-player-hp
+  [stats arena]
+  (let [player-ids (set (keys stats))]
+    (reduce
+     (fn [stats-acc cell]
+       (let [cell-uuid (get-in cell [:contents :uuid])]
+         (if (contains? player-ids cell-uuid)
+           (assoc-in stats-acc [cell-uuid :hp] (get-in cell [:contents :hp]))
+           stats-acc)))
+     stats (flatten arena))))
+
+(defn get-player-stats
+  "Returns stats from game-state"
+  [game-state]
+  (-> {}
+      (add-player-scores (:players game-state))
+      (add-player-hp (get-in game-state [:frame
+                                         :frame/arena]))
+      vals))
+
 ;; Broadcast helper functions
 
 (defn- broadcast-to-viewers
@@ -225,7 +261,8 @@
       ;; Sends the current game frame to the frontend
       ((send-arena arena) chan-id)
 
-      ;; TODO: Sends the players to the front end instead of fake data
+      ;; Sends the stats (player info)
+      ((send-stats (get-player-stats game-state)) chan-id)
 
 
       ;; Sends the game info to the front end

--- a/src/wombats/sockets/game.clj
+++ b/src/wombats/sockets/game.clj
@@ -130,6 +130,25 @@
   [game-id chan-id]
   (:color (get-game-room-player game-id chan-id)))
 
+;; Broadcast functions
+
+(defn broadcast-arena
+  [game-id arena]
+  (let [channel-ids (get-game-room-channel-ids game-id)]
+    (doseq [channel-id channel-ids]
+      (send-message channel-id
+                    {:meta {:msg-type :frame-update}
+                     :payload arena}))))
+
+(defn broadcast-stats
+  [game-id stats]
+  (let [viewers (get-game-room-channel-ids game-id)]
+
+    (doseq [chan-id viewers]
+      (send-message chan-id
+                    {:meta {:msg-type :stats-update}
+                     :payload (vec stats)}))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Handlers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -195,25 +214,6 @@
                                :color (get-player-color game-id chan-id)
                                :timestamp (str (l/local-now))}]
         (broadcast-game-message game-id formatted-message)))))
-
-;; Broadcast functions
-
-(defn broadcast-arena
-  [game-id arena]
-  (let [channel-ids (get-game-room-channel-ids game-id)]
-    (doseq [channel-id channel-ids]
-      (send-message channel-id
-                    {:meta {:msg-type :frame-update}
-                     :payload arena}))))
-
-(defn broadcast-stats
-  [game-id stats]
-  (let [viewers (get-game-room-channel-ids game-id)]
-
-    (doseq [chan-id viewers]
-      (send-message chan-id
-                    {:meta {:msg-type :stats-update}
-                     :payload (vec stats)}))))
 
 (defn create-socket-handler-map
   "Allows for adding custom handlers that respond to namespaced messages

--- a/src/wombats/sockets/game.clj
+++ b/src/wombats/sockets/game.clj
@@ -222,14 +222,14 @@
              [game-id :players chan-id]
              (assoc socket-user :color (:player/color player)))
 
-      ;; Sends the initial frame to the frontend
-      (broadcast-arena game-id arena)
+      ;; Sends the current game frame to the frontend
+      ((send-arena arena) chan-id)
 
       ;; TODO: Sends the players to the front end instead of fake data
 
 
       ;; Sends the game info to the front end
-      (broadcast-game-info game-id game))))
+      ((send-game-info game) chan-id))))
 
 (defn- leave-game
   [_]


### PR DESCRIPTION
# Problem
When you go to a game's page, you don't get enough information sent back (current arena state if the game isn't running, game name, max players, current players, etc.).

# Solution
With this change, I broadcast game info, through sockets, whenever somebody joins a game. I'm not sure that we really need to broadcast it to everyone (could probably get away with just broadcasting to the channel that joined). We'll need to think about this. I still need to send a `stats-update` so that the client knows which bots are in the game.