### PR TITLE
Feature/#169 game scheduler

### DIFF
--- a/src/wombats/daos/core.clj
+++ b/src/wombats/daos/core.clj
@@ -2,7 +2,8 @@
   (:require [datomic.api :as d]
             [wombats.daos.user :as user]
             [wombats.daos.arena :as arena]
-            [wombats.daos.game :as game]))
+            [wombats.daos.game :as game]
+            [wombats.scheduler.core :as scheduler]))
 
 (defn init-dao-map
   "Creates a map of all the data accessors that can be used inside of handlers / socket connections.
@@ -10,6 +11,11 @@
   access to these functions."
   [{:keys [conn] :as datomic}
    aws-credentials]
+
+  ;; Go through all the pending games, and schedule them
+  (scheduler/schedule-pending-games (game/get-all-pending-games conn)
+                                    (game/start-game conn aws-credentials))
+
   {;; User DAOS
    :get-users (user/get-users conn)
    :get-user-by-id (user/get-user-by-id conn)
@@ -36,6 +42,7 @@
    :retract-arena (arena/retract-arena conn)
    ;; Game Management DAOS
    :get-all-games (game/get-all-games conn)
+   :get-all-pending-games (game/get-all-pending-games conn)
    :get-game-eids-by-status (game/get-game-eids-by-status conn)
    :get-game-eids-by-player (game/get-game-eids-by-player conn)
    :get-games-by-eids (game/get-games-by-eids conn)

--- a/src/wombats/daos/game.clj
+++ b/src/wombats/daos/game.clj
@@ -86,6 +86,12 @@
     ((get-games-by-eids conn)
      ((get-all-game-eids conn)))))
 
+(defn get-all-pending-games
+  [conn]
+  (fn []
+    ((get-games-by-eids conn)
+     ((get-game-eids-by-status conn) [:pending-open :pending-closed]))))
+
 (defn get-game-by-id
   [conn]
   (fn [game-id]

--- a/src/wombats/handlers/game.clj
+++ b/src/wombats/handlers/game.clj
@@ -210,7 +210,7 @@
              game-record (get-game game-id)]
 
          (scheduler/schedule-game game-record 
-                                  #(start-game-fn game-record))
+                                  start-game-fn)
 
          (assoc context :response (assoc response
                                          :status 201

--- a/src/wombats/handlers/game.clj
+++ b/src/wombats/handlers/game.clj
@@ -188,6 +188,7 @@
      (let [add-game (dao/get-fn :add-game context)
            get-game (dao/get-fn :get-game-by-id context)
            get-arena (dao/get-fn :get-arena-by-id context)
+           start-game-fn (dao/get-fn :start-game context)
            arena-id (get-in request [:query-params :arena-id])
            game (set-game-defaults (:edn-params request))
            arena-config (get-arena arena-id)]
@@ -206,7 +207,8 @@
                            game-arena)
              game-record (get-game game-id)]
 
-         (scheduler/schedule-game game-record)
+         (scheduler/schedule-game game-record 
+                                  #(start-game-fn game-record))
 
          (assoc context :response (assoc response
                                          :status 201

--- a/src/wombats/handlers/game.clj
+++ b/src/wombats/handlers/game.clj
@@ -7,7 +7,8 @@
             [wombats.handlers.helpers :refer [wombat-error]]
             [wombats.daos.helpers :as dao]
             [wombats.specs.utils :as sutils]
-            [wombats.arena.core :refer [generate-arena]]))
+            [wombats.arena.core :refer [generate-arena]]
+            [wombats.scheduler.core :as scheduler]))
 
 (def ^:private game-body-sample
   #:game{:name "New Game"
@@ -204,6 +205,8 @@
                            (:db/id arena-config)
                            game-arena)
              game-record (get-game game-id)]
+
+         (scheduler/schedule-game game-record)
 
          (assoc context :response (assoc response
                                          :status 201

--- a/src/wombats/scheduler/core.clj
+++ b/src/wombats/scheduler/core.clj
@@ -1,0 +1,24 @@
+(ns wombats.scheduler.core
+  (:require [chime :refer [chime-at]]
+            [clj-time.core :as t]
+            [clj-time.coerce :as c]))
+
+(defn- start-game
+  "Starts the game"
+  []
+  (prn "STARTING GAME"))
+
+(defn schedule-game
+  "Takes in a game, and adds a hook to start the game at start"
+  [game]
+  (let [start-time (c/from-date (:game/start-time game))]
+
+    (if (t/after? (t/now) start-time)
+      ;; Start time has already passed
+      (start-game)
+      ;; Set interval to start game in the future
+      (chime-at [(-> start-time)]
+                (fn [time]
+                  (start-game))))
+
+    nil))

--- a/src/wombats/scheduler/core.clj
+++ b/src/wombats/scheduler/core.clj
@@ -14,4 +14,13 @@
       ;; Set interval to start game in the future
       (chime-at [(-> start-time)]
                 (fn [time]
-                  (start-game-fn))))))
+                  (start-game-fn))
+
+                ;; TODO: Proper logging
+                {:on-finished
+                 (fn [] 
+                   (prn "Started game."))
+                 
+                 :error-handler 
+                 (fn [e]
+                   (prn "Error starting game."))}))))

--- a/src/wombats/scheduler/core.clj
+++ b/src/wombats/scheduler/core.clj
@@ -10,11 +10,11 @@
 
     (if (t/after? (t/now) start-time)
       ;; Start time has already passed
-      (start-game-fn)
+      (start-game-fn game)
       ;; Set interval to start game in the future
       (chime-at [(-> start-time)]
                 (fn [time]
-                  (start-game-fn))
+                  (start-game-fn game))
 
                 ;; TODO: Proper logging
                 {:on-finished
@@ -24,3 +24,9 @@
                  :error-handler 
                  (fn [e]
                    (prn "Error starting game."))}))))
+
+(defn schedule-pending-games
+  [get-games-fn start-game-fn]
+  (let [games (get-games-fn)]
+    (doseq [game games]
+      (schedule-game game start-game-fn))))

--- a/src/wombats/scheduler/core.clj
+++ b/src/wombats/scheduler/core.clj
@@ -3,22 +3,15 @@
             [clj-time.core :as t]
             [clj-time.coerce :as c]))
 
-(defn- start-game
-  "Starts the game"
-  []
-  (prn "STARTING GAME"))
-
 (defn schedule-game
   "Takes in a game, and adds a hook to start the game at start"
-  [game]
+  [game start-game-fn]
   (let [start-time (c/from-date (:game/start-time game))]
 
     (if (t/after? (t/now) start-time)
       ;; Start time has already passed
-      (start-game)
+      (start-game-fn)
       ;; Set interval to start game in the future
       (chime-at [(-> start-time)]
                 (fn [time]
-                  (start-game))))
-
-    nil))
+                  (start-game-fn))))))


### PR DESCRIPTION
## Problem
Currently games require a manual trigger through Swagger. 

## Solution
Use Chime to trigger the game start based on `start-time`. Every time the server starts, the scheduler is repopulated. 