### PR TITLE
Bugfix - User Role Bug

### DIFF
--- a/src/wombats/daos/user.clj
+++ b/src/wombats/daos/user.clj
@@ -71,7 +71,8 @@
                   :user/avatar-url avatar_url}]
       (if-not current-user-id
         (d/transact-async conn [(merge update {:db/id (d/tempid :db.part/user)
-                                               :user/id (gen-id)})])
+                                               :user/id (gen-id)
+                                               :user/roles [:user.roles/user]})])
         (d/transact-async conn [(merge update {:user/id current-user-id})])))))
 
 (defn remove-access-token


### PR DESCRIPTION
### Problem

Users that join for the first time are unauthorized to interact with the application if they are not seeded with roles initially.

### Solution 

Add the `user` role to all new users