### PR TITLE
[Bugfix] Send game info along with stats.

### DIFF
--- a/src/wombats/daos/game.clj
+++ b/src/wombats/daos/game.clj
@@ -304,8 +304,7 @@
           (d/transact conn trx)
 
           (let [game-state ((get-game-state-by-id conn) game-id)]
-            (game-sockets/broadcast-game-info game-state)
-            (game-sockets/broadcast-stats game-state)))))))
+            (game-sockets/broadcast-game-info game-state)))))))
 
 (defn- update-frame-state
   [conn]

--- a/src/wombats/game/core.clj
+++ b/src/wombats/game/core.clj
@@ -3,7 +3,6 @@
             [clj-time.core :as t]
             [wombats.game.initializers :as i]
             [wombats.game.finalizers :as f]
-            [wombats.game.player-stats :refer [get-player-stats]]
             [wombats.game.processor :as p]
             [wombats.arena.utils :as au]
             [wombats.scheduler.core :as scheduler]
@@ -78,7 +77,7 @@
       ;; TODO: Remove this timeout
       (timeout-frame 500)
       (game-sockets/broadcast-arena)
-      (game-sockets/broadcast-stats)
+      (game-sockets/broadcast-game-info)
       (push-frame-to-datomic update-frame)))
 
 (defn- game-loop

--- a/src/wombats/sockets/game.clj
+++ b/src/wombats/sockets/game.clj
@@ -8,7 +8,6 @@
             [clj-time.periodic :as p]
             [chime :refer [chime-at]]
             [io.pedestal.http.jetty.websockets :as ws]
-            [wombats.game.player-stats :refer [get-player-stats]]
             [wombats.sockets.messages :as m]))
 
 (def ^:private game-rooms (atom {}))
@@ -137,15 +136,9 @@
                         (m/arena-message (:frame/arena frame)))
   game-state)
 
-(defn broadcast-stats
+(defn broadcast-game-info
   [{:keys [game-id] :as game-state}]
   (broadcast-to-viewers game-id
-                        (m/stats-message (get-player-stats game-state)))
-  game-state)
-
-(defn broadcast-game-info
-  [game-state]
-  (broadcast-to-viewers (get-in game-state [:game-config :game/id])
                         (m/game-info-message game-state))
   game-state)
 
@@ -188,10 +181,6 @@
       ;; Sends the current game frame to the frontend
       (send-message chan-id
                     (m/arena-message arena))
-
-      ;; Sends the stats (player info)
-      (send-message chan-id
-                    (m/stats-message (get-player-stats game-state)))
 
       ;; Sends the game info to the front end
       (send-message chan-id

--- a/src/wombats/sockets/messages.clj
+++ b/src/wombats/sockets/messages.clj
@@ -1,5 +1,6 @@
 (ns wombats.sockets.messages
-  (:require [clojure.edn :as edn]))
+  (:require [clojure.edn :as edn]
+            [wombats.game.player-stats :refer [get-player-stats]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper functions
@@ -114,14 +115,10 @@
                 :player-count (count (:players game-state))
                 :name (:game/name game-config)
                 :status (:game/status game-config)
-                :game-winner (get-game-winner game-state)}))
+                :game-winner (get-game-winner game-state)
+                :stats (vec (get-player-stats game-state))}))
 
 (defn handshake-message
   [chan-id]
   (get-message :handshake
                {:chan-id chan-id}))
-
-(defn stats-message
-  [stats]
-  (get-message :stats-update
-               (vec stats)))


### PR DESCRIPTION
## Problem
Occasionally, hp was sent as nil when the game was active.

## Solution
There was occasionally race conditions resulting in stats and game info from being in sync. By sending them together, they're always guaranteed to correspond to each other. This also fixes issue with cumulative scores.