### PR TITLE
Bugfix for scoring

### DIFF
--- a/src/wombats/components/logger.clj
+++ b/src/wombats/components/logger.clj
@@ -3,7 +3,7 @@
             [taoensso.timbre :as timbre]
             [taoensso.timbre.appenders.core :as appenders]))
 
-(def ^:private
+(defonce ^:private
   appender-map
   {:spit appenders/spit-appender
    :println appenders/println-appender})

--- a/src/wombats/datomic/db_functions.clj
+++ b/src/wombats/datomic/db_functions.clj
@@ -69,6 +69,7 @@
              (let [player-tmpid (d/tempid :db.part/user)
                    stats-tmpid (d/tempid :db.part/user)
                    player-trx {:db/id player-tmpid
+                               :player/id (str (java.util.UUID/randomUUID))
                                :player/user user-eid
                                :player/wombat wombat-eid
                                :player/color color}


### PR DESCRIPTION
# PR for issue #277 .

## Implementation Notes:

The problem was game state was populating each users stats incorrectly between rounds. This caused the database transactions to fail on each frame update resulting in scores to be updated in state only and not persisted across rounds.  

## Breaking changes:

None