### PR TITLE
[Feature] Update game message format

### DIFF
--- a/src/wombats/sockets/messages.clj
+++ b/src/wombats/sockets/messages.clj
@@ -112,7 +112,7 @@
                {:game/round-start-time (get-start-time game-state)
                 :game/round-number (get-round-number game-state)
                 :game/max-players (:game/max-players game-config)
-                :game/players (:players game-state)
+                :game/player-count (count (:players game-state))
                 :game/name (:game/name game-config)
                 :game/status (:game/status game-config)
                 :game/winner (get-game-winner game-state)

--- a/src/wombats/sockets/messages.clj
+++ b/src/wombats/sockets/messages.clj
@@ -109,14 +109,15 @@
   [{:keys [game-config] :as game-state}]
 
   (get-message :game-info
-               {:round-start-time (get-start-time game-state)
-                :round-number (get-round-number game-state)
-                :max-players (:game/max-players game-config)
-                :player-count (count (:players game-state))
-                :name (:game/name game-config)
-                :status (:game/status game-config)
-                :game-winner (get-game-winner game-state)
-                :stats (vec (get-player-stats game-state))}))
+               {:game/round-start-time (get-start-time game-state)
+                :game/round-number (get-round-number game-state)
+                :game/max-players (:game/max-players game-config)
+                :game/players (:players game-state)
+                :game/name (:game/name game-config)
+                :game/status (:game/status game-config)
+                :game/winner (get-game-winner game-state)
+                :game/stats (vec (get-player-stats game-state))
+                :game/is-private (:game/is-private game-config)}))
 
 (defn handshake-message
   [chan-id]

--- a/src/wombats/sockets/messages.clj
+++ b/src/wombats/sockets/messages.clj
@@ -109,7 +109,8 @@
   [{:keys [game-config] :as game-state}]
 
   (get-message :game-info
-               {:game/round-start-time (get-start-time game-state)
+               {:game/id (:game/id game-config)
+                :game/round-start-time (get-start-time game-state)
                 :game/round-number (get-round-number game-state)
                 :game/max-players (:game/max-players game-config)
                 :game/player-count (count (:players game-state))

--- a/src/wombats/sockets/messages.clj
+++ b/src/wombats/sockets/messages.clj
@@ -110,7 +110,7 @@
 
   (get-message :game-info
                {:game/id (:game/id game-config)
-                :game/round-start-time (get-start-time game-state)
+                :game/start-time (get-start-time game-state)
                 :game/round-number (get-round-number game-state)
                 :game/max-players (:game/max-players game-config)
                 :game/player-count (count (:players game-state))


### PR DESCRIPTION
# PR for updating game message.

## Implementation Notes:
- Currently the socket messages sent when you join a game are significantly different from the results from the get request. This updates the message so it more closely matches the GET request (that way we can merge the results into the existing db).

## Breaking changes:
- Frontend requires an update before this is merged.