### PR TITLE
Fixed Security Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ CHANGELOG
 * None
 
 **Bug Fixes**
-* None
+* Strict-Transport-Security remove includeSubdomains
+    [C.P. Dehli][/dehli] *No Issue*
 
 ## QA (3.23.2017)
 **Enhancements**

--- a/src/wombats/components/pedestal.clj
+++ b/src/wombats/components/pedestal.clj
@@ -37,6 +37,7 @@
                               allowed-origin?)
      ::http/routes api-routes
      ::http/port port
+     ::http/secure-headers {:hsts-settings (sec-headers/hsts-header 31536000)}
      ::http/type type
      ::http/join? join?
      ::http/container-options (merge container-options


### PR DESCRIPTION
# PR for Security Headers.

## Ready for a PR?
 - [X] I have updated the CHANGELOG with an entry including a description, a link to my profile, and a link to the issue ticket. This change is filed under an Enhancement or Bug Fix, is shown under the relevant release tag name, and is included in my PR branch. 
 
## Implementation Notes:
- Removed `includeSubdomains` from pedestal headers. This was needed because it was resulting in the `qa.api.wombats.io` redirecting to `https://` after going to `https://wombats.io`.

## Breaking changes:
- None